### PR TITLE
Change: Use serializer custom handler services if exists

### DIFF
--- a/modules/swagger-codegen/src/main/resources/php-symfony/serialization/JmsSerializer.mustache
+++ b/modules/swagger-codegen/src/main/resources/php-symfony/serialization/JmsSerializer.mustache
@@ -2,37 +2,57 @@
 
 namespace {{servicePackage}};
 
+use JMS\Serializer\Handler\PropelCollectionHandler;
+use JMS\Serializer\Handler\StdClassHandler;
 use JMS\Serializer\SerializerBuilder;
 use JMS\Serializer\Naming\CamelCaseNamingStrategy;
 use JMS\Serializer\Naming\SerializedNameAnnotationStrategy;
 use JMS\Serializer\XmlDeserializationVisitor;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class JmsSerializer implements SerializerInterface
 {
     protected $serializer;
 
-    public function __construct()
+    protected $deserializer;
+
+    public function __construct(ContainerInterface $container)
     {
         $naming_strategy = new SerializedNameAnnotationStrategy(new CamelCaseNamingStrategy());
-        $this->serializer = SerializerBuilder::create()
+        $this->deserializer = SerializerBuilder::create()
             ->setDeserializationVisitor('json', new StrictJsonDeserializationVisitor($naming_strategy))
             ->setDeserializationVisitor('xml', new XmlDeserializationVisitor($naming_strategy))
+            ->build();
+
+        $dateHandler = $container->get('jms_serializer.datetime_handler');
+        $phpCollectionHandler = $container->get('jms_serializer.php_collection_handler');
+        $arrayCollectionHandler = $container->get('jms_serializer.array_collection_handler');
+        $this->serializer = SerializerBuilder::create()
+            ->configureHandlers(
+                function ($registry) use ($dateHandler, $phpCollectionHandler, $arrayCollectionHandler) {
+                    $registry->registerSubscribingHandler($dateHandler);
+                    $registry->registerSubscribingHandler(new StdClassHandler());
+                    $registry->registerSubscribingHandler($phpCollectionHandler);
+                    $registry->registerSubscribingHandler($arrayCollectionHandler);
+                    $registry->registerSubscribingHandler(new PropelCollectionHandler());
+                }
+            )
             ->build();
     }
 
     public function serialize($data, $format)
     {
-        return SerializerBuilder::create()->build()->serialize($data, $this->convertFormat($format));
+        return $this->serializer->serialize($data, $this->convertFormat($format));
     }
 
     public function deserialize($data, $type, $format)
     {
         if ($format == 'string') {
-            return $this->deserializeString($data, $type);           
+            return $this->deserializeString($data, $type);
         }
 
         // If we end up here, let JMS serializer handle the deserialization
-        return $this->serializer->deserialize($data, $type, $this->convertFormat($format));
+        return $this->deserializer->deserialize($data, $type, $this->convertFormat($format));
     }
 
     private function convertFormat($format)


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

