### PR TITLE
fix(serializer): set default value for serialisation, FURM-1641

### DIFF
--- a/modules/swagger-codegen/src/main/resources/php-symfony/serialization/JmsSerializer.mustache
+++ b/modules/swagger-codegen/src/main/resources/php-symfony/serialization/JmsSerializer.mustache
@@ -2,6 +2,8 @@
 
 namespace {{servicePackage}};
 
+use JMS\Serializer\Naming\IdenticalPropertyNamingStrategy;
+use JMS\Serializer\Naming\SerializedNameAnnotationStrategy;
 use JMS\Serializer\SerializerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -14,10 +16,18 @@ class JmsSerializer implements SerializerInterface
     public function __construct(ContainerInterface $container)
     {
         $this->deserializer = SerializerBuilder::create()
-            ->build();
+        ->setPropertyNamingStrategy(
+            new SerializedNameAnnotationStrategy(
+                new IdenticalPropertyNamingStrategy()
+            )
+        )->build();
 
         $this->serializer = SerializerBuilder::create()
-            ->build();
+        ->setPropertyNamingStrategy(
+            new SerializedNameAnnotationStrategy(
+                new IdenticalPropertyNamingStrategy()
+            )
+        )->build();
     }
 
     public function serialize($data, $format)
@@ -101,7 +111,7 @@ class JmsSerializer implements SerializerInterface
             case 'pipes':
                 $data = explode('|', $data);
                 break;
-            default;
+            default:
                 $data = [];
         }
 

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Service/JmsSerializer.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Service/JmsSerializer.php
@@ -2,6 +2,8 @@
 
 namespace Swagger\Server\Service;
 
+use JMS\Serializer\Naming\IdenticalPropertyNamingStrategy;
+use JMS\Serializer\Naming\SerializedNameAnnotationStrategy;
 use JMS\Serializer\SerializerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -14,10 +16,18 @@ class JmsSerializer implements SerializerInterface
     public function __construct(ContainerInterface $container)
     {
         $this->deserializer = SerializerBuilder::create()
-            ->build();
+        ->setPropertyNamingStrategy(
+            new SerializedNameAnnotationStrategy(
+                new IdenticalPropertyNamingStrategy()
+            )
+        )->build();
 
         $this->serializer = SerializerBuilder::create()
-            ->build();
+        ->setPropertyNamingStrategy(
+            new SerializedNameAnnotationStrategy(
+                new IdenticalPropertyNamingStrategy()
+            )
+        )->build();
     }
 
     public function serialize($data, $format)
@@ -101,7 +111,7 @@ class JmsSerializer implements SerializerInterface
             case 'pipes':
                 $data = explode('|', $data);
                 break;
-            default;
+            default:
                 $data = [];
         }
 


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

